### PR TITLE
do not merge /Quick change everything

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,14 +25,26 @@ export default class Autolink extends Component {
           case 'instagram':
             return `instagram://tag?name=${tag}`;
           case 'twitter':
-            return `twitter://search?query=%23${tag}`;
+            const twitterURL = `twitter://search?query=%23${tag}`;
+            Linking.canOpenURL(url).then(supported => {
+                if (!supported) {
+                    return `https://www.twitter.com/search?q=${tag}`;
+                }
+                return url;
+            })
           default:
             return match.getMatchedText();
         }
       case 'phone':
         return `tel:${match.getNumber()}`;
       case 'twitter':
-        return `twitter://user?screen_name=${encodeURIComponent(match.getTwitterHandle())}`;
+        const url = `twitter://user?screen_name=${encodeURIComponent(match.getTwitterHandle())}`;
+        Linking.canOpenURL(url).then(supported => {
+            if (!supported) {
+                return `https://www.twitter.com/${encodeURIComponent(match.getTwitterHandle())}`;
+            }
+            return url;
+        })
       case 'url':
         return match.getAnchorHref();
       default:

--- a/src/index.js
+++ b/src/index.js
@@ -38,10 +38,11 @@ export default class Autolink extends Component {
       case 'phone':
         return `tel:${match.getNumber()}`;
       case 'twitter':
-        const url = `twitter://user?screen_name=${encodeURIComponent(match.getTwitterHandle())}`;
+        const twitterHandle = encodeURIComponent(match.getTwitterHandle());
+        const url = `twitter://user?screen_name=${twitterHandle}`;
         Linking.canOpenURL(url).then(supported => {
             if (!supported) {
-                return `https://www.twitter.com/${encodeURIComponent(match.getTwitterHandle())}`;
+                return `https://www.twitter.com/${twitterHandle}`;
             }
             return url;
         })

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export default class Autolink extends Component {
           case 'instagram':
             return `instagram://tag?name=${tag}`;
           case 'twitter':
-            const twitterURL = `twitter://search?query=%23${tag}`;
+            const url = `twitter://search?query=%23${tag}`;
             Linking.canOpenURL(url).then(supported => {
                 if (!supported) {
                     return `https://www.twitter.com/search?q=${tag}`;

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ export default class Autolink extends Component {
           default:
             Linking.openURL(match.getMatchedText());
         }
+        break;
       case 'phone':
         return Linking.openURL(`tel:${match.getNumber()}`);
       case 'twitter':

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import Autolinker from 'autolinker';
 import {Linking, StyleSheet, Text} from 'react-native';
 
 export default class Autolink extends Component {
-  _onPress(url, match) {
+  _onPress(match) {
     let type = match.getType();
 
     switch (type) {
@@ -32,7 +32,8 @@ export default class Autolink extends Component {
                 } else {
                     Linking.openURL(url);
                 }
-            })
+            });
+            break;
           default:
             Linking.openURL(match.getMatchedText());
         }
@@ -46,8 +47,9 @@ export default class Autolink extends Component {
                 Linking.openURL(`https://www.twitter.com/${twitterHandle}`);
             } else {
                 Linking.openURL(url);
-            })
-        }
+            }
+        });
+        break;
       case 'url':
         Linking.openURL(match.getAnchorHref());
       default:
@@ -55,14 +57,14 @@ export default class Autolink extends Component {
       }
   }
 
-  renderLink(text, url, match, index) {
+  renderLink(text, match, index) {
     let truncated = (this.props.truncate > 0) ? Autolinker.truncate.TruncateSmart(text, this.props.truncate, this.props.truncateChars) : text;
 
     return (
       <Text
         key={index}
         style={[styles.link, this.props.linkStyle]}
-        onPress={this._onPress.bind(this, match)}>
+        onPress={() => { this._onPress(match) }}>
           {truncated}
       </Text>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -12,53 +12,47 @@ import Autolinker from 'autolinker';
 import {Linking, StyleSheet, Text} from 'react-native';
 
 export default class Autolink extends Component {
-  getURL(match) {
+  _onPress(url, match) {
     let type = match.getType();
 
     switch (type) {
       case 'email':
-        return `mailto:${encodeURIComponent(match.getEmail())}`;
+        Linking.openURL(`mailto:${encodeURIComponent(match.getEmail())}`);
       case 'hashtag':
         let tag = encodeURIComponent(match.getHashtag());
 
         switch (this.props.hashtag) {
           case 'instagram':
-            return `instagram://tag?name=${tag}`;
+            Linking.openURL(`instagram://tag?name=${tag}`);
           case 'twitter':
             const url = `twitter://search?query=%23${tag}`;
             Linking.canOpenURL(url).then(supported => {
                 if (!supported) {
-                    return `https://www.twitter.com/search?q=${tag}`;
+                    Linking.openURL(`https://www.twitter.com/search?q=${tag}`);
+                } else {
+                    Linking.openURL(url);
                 }
-                return url;
             })
           default:
-            return match.getMatchedText();
+            Linking.openURL(match.getMatchedText());
         }
       case 'phone':
-        return `tel:${match.getNumber()}`;
+        return Linking.openURL(`tel:${match.getNumber()}`);
       case 'twitter':
         const twitterHandle = encodeURIComponent(match.getTwitterHandle());
         const url = `twitter://user?screen_name=${twitterHandle}`;
         Linking.canOpenURL(url).then(supported => {
             if (!supported) {
-                return `https://www.twitter.com/${twitterHandle}`;
-            }
-            return url;
-        })
+                Linking.openURL(`https://www.twitter.com/${twitterHandle}`);
+            } else {
+                Linking.openURL(url);
+            })
+        }
       case 'url':
-        return match.getAnchorHref();
+        Linking.openURL(match.getAnchorHref());
       default:
-        return match.getMatchedText();
-    }
-  }
-
-  _onPress(url, match) {
-    if (this.props.onPress) {
-      this.props.onPress(url, match);
-    } else {
-      Linking.openURL(url);
-    }
+        Linking.openURL(match.getMatchedText());
+      }
   }
 
   renderLink(text, url, match, index) {
@@ -68,7 +62,7 @@ export default class Autolink extends Component {
       <Text
         key={index}
         style={[styles.link, this.props.linkStyle]}
-        onPress={this._onPress.bind(this, url, match)}>
+        onPress={this._onPress.bind(this, match)}>
           {truncated}
       </Text>
     );
@@ -142,7 +136,7 @@ export default class Autolink extends Component {
           case 'phone':
           case 'twitter':
           case 'url':
-            return (renderLink) ? renderLink(match.getAnchorText(), this.getURL(match), match, index) : this.renderLink(match.getAnchorText(), this.getURL(match), match, index);
+            return (renderLink) ? renderLink(match.getAnchorText(), match, index) : this.renderLink(match.getAnchorText(), match, index);
           default:
             return part;
         }


### PR DESCRIPTION
Why?

Linking.canOpenURL returns a promise - binding will not wait for it to complete before assigning the URL to the link (ending up with 'undefined' links). This avoids that issue by calculating the URL when the button is clicked and calling it directly from there.
